### PR TITLE
fix travis build img rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 GanttProject
 ============
-[![Build Status] (https://travis-ci.org/bardsoftware/ganttproject.svg?branch=master)](https://travis-ci.org/bardsoftware/ganttproject)
+[![Build Status](https://travis-ci.org/bardsoftware/ganttproject.svg?branch=master)](https://travis-ci.org/bardsoftware/ganttproject)
 
 GanttProject is an open-source desktop project scheduling and management tool. It is written in Java/Swing.
 


### PR DESCRIPTION
there was a space in the markdown, preventing the markdown renderer to correctly generate the img html tag